### PR TITLE
Optimize decode_2chars, parse_string, decode

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name hexstring)
  (public_name hexstring)
- (libraries str)
+ (libraries)
  (inline_tests)
  (preprocess
   (pps ppx_inline_test)))

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -93,15 +93,14 @@ let decode hexstring =
   let len = String.length hexstring in
   if len mod 2 <> 0 then
     Error "length must be a multiple of 2"
-  else
-    if len = 0 then
+  else if len = 0 then
       Ok Bytes.empty
-    else
-      let len = String.length hexstring in
-      let res = Bytes.make (len / 2) '\x00' in
-      match aux 0 (Bytes.length res) hexstring res with
-      | Error i -> Error (Printf.sprintf "invalid char at %d" i)
-      | Ok bytes -> Ok bytes
+  else
+    let len = String.length hexstring in
+    let res = Bytes.make (len / 2) '\x00' in
+    match aux 0 (Bytes.length res) hexstring res with
+    | Error i -> Error (Printf.sprintf "invalid char at %d" i)
+    | Ok bytes -> Ok bytes
 
 let%test "decoding empty hexstring" =
   let d = decode "" in

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -52,26 +52,26 @@ let decode_1char = function
   | 'f' -> Some 15
   | _ -> None
 
-let decode_2chars c1 c2 : (char, string) result =
+let decode_2chars c1 c2 : char option =
   let fst = decode_1char c1 in
   let snd = decode_1char c2 in
   match (fst, snd) with
-  | None, _ | _, None -> Error "nope"
+  | None, _ | _, None -> None
   | Some fst, Some snd ->
       let res = (fst lsl 4) lxor snd in
-      Ok (char_of_int res)
+      Some (char_of_int res)
 
 let%test "decoding two chars 01" =
   let d = decode_2chars '0' '1' in
-  d = Ok '\x01'
+  d = Some '\x01'
 
 let%test "decoding two chars ff" =
   let d = decode_2chars 'f' 'f' in
-  d = Ok '\xff'
+  d = Some '\xff'
 
 let%test "decoding two erroneous chars" =
   let d = decode_2chars 'z' 'f' in
-  Result.is_error d
+  Option.is_none d
 
 (* decoding hexstring -> bytearray *)
 
@@ -82,8 +82,8 @@ let parse_string (ss : string) : (bytes, int) result =
       let c1 = ss.[pos] in
       let c2 = ss.[pos + 1] in
       match decode_2chars c1 c2 with
-      | Error _ -> Error pos
-      | Ok b ->
+      | None -> Error pos
+      | Some b ->
         Bytes.set res res_cur_pos b;
         aux (succ res_cur_pos) res_len ss res
     )

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -96,7 +96,6 @@ let decode hexstring =
   else if len = 0 then
       Ok Bytes.empty
   else
-    let len = String.length hexstring in
     let res = Bytes.make (len / 2) '\x00' in
     match aux 0 (Bytes.length res) hexstring res with
     | Error i -> Error (Printf.sprintf "invalid char at %d" i)

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -52,7 +52,7 @@ let decode_1char = function
   | 'f' -> Some 15
   | _ -> None
 
-let decode_2chars ((c1, c2) : char * char) : (char, string) result =
+let decode_2chars c1 c2 : (char, string) result =
   let fst = decode_1char c1 in
   let snd = decode_1char c2 in
   match (fst, snd) with
@@ -62,15 +62,15 @@ let decode_2chars ((c1, c2) : char * char) : (char, string) result =
       Ok (char_of_int res)
 
 let%test "decoding two chars 01" =
-  let d = decode_2chars ('0', '1') in
+  let d = decode_2chars '0' '1' in
   d = Ok '\x01'
 
 let%test "decoding two chars ff" =
-  let d = decode_2chars ('f', 'f') in
+  let d = decode_2chars 'f' 'f' in
   d = Ok '\xff'
 
 let%test "decoding two erroneous chars" =
-  let d = decode_2chars ('z', 'f') in
+  let d = decode_2chars 'z' 'f' in
   Result.is_error d
 
 (* decoding hexstring -> bytearray *)
@@ -81,7 +81,7 @@ let parse_string (ss : string) : (bytes, int) result =
       let pos = 2 * res_cur_pos in
       let c1 = ss.[pos] in
       let c2 = ss.[pos + 1] in
-      match decode_2chars (c1, c2) with
+      match decode_2chars c1 c2 with
       | Error _ -> Error pos
       | Ok b ->
         Bytes.set res res_cur_pos b;

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -75,8 +75,8 @@ let%test "decoding two erroneous chars" =
 
 (* decoding hexstring -> bytearray *)
 
-let parse_string (ss : string) : (bytes, int) result =
-  let rec aux res_cur_pos res_len ss res =
+let decode hexstring =
+  let rec aux res_cur_pos res_len ss res : (bytes, int) result =
     if res_cur_pos < res_len then (
       let pos = 2 * res_cur_pos in
       let c1 = ss.[pos] in
@@ -90,21 +90,18 @@ let parse_string (ss : string) : (bytes, int) result =
     else
       Ok res
   in
-  match String.length ss with
-  | 0 -> Ok Bytes.empty
-  | _ ->
-    let len = String.length ss in
-    let res = Bytes.make (len / 2) '\x00' in
-    aux 0 (Bytes.length res) ss res
-
-let decode hexstring =
   let len = String.length hexstring in
   if len mod 2 <> 0 then
     Error "length must be a multiple of 2"
   else
-    match parse_string hexstring with
-    | Error i -> Error (Printf.sprintf "invalid char at %d" i)
-    | Ok bytes -> Ok bytes
+    if len = 0 then
+      Ok Bytes.empty
+    else
+      let len = String.length hexstring in
+      let res = Bytes.make (len / 2) '\x00' in
+      match aux 0 (Bytes.length res) hexstring res with
+      | Error i -> Error (Printf.sprintf "invalid char at %d" i)
+      | Ok bytes -> Ok bytes
 
 let%test "decoding empty hexstring" =
   let d = decode "" in

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -8,8 +8,8 @@ let encode (bytearray : bytes) : string =
     assert (x >= 0);
     assert (x < 16);
     char_of_int
-      (if x < 10 then x + start_of_digit_0_in_ascii_table
-      else x - 10 + start_of_lower_case_a_in_ascii_table)
+      ( if x < 10 then x + start_of_digit_0_in_ascii_table
+      else x - 10 + start_of_lower_case_a_in_ascii_table )
   in
   let rec aux bytearray len cur_pos buf =
     if cur_pos < len then (
@@ -18,7 +18,7 @@ let encode (bytearray : bytes) : string =
       let c2 = hex_digit_of_int (x land 0x0F) in
       Bytes.set buf (cur_pos * 2) c1;
       Bytes.set buf ((cur_pos * 2) + 1) c2;
-      aux bytearray len (succ cur_pos) buf)
+      aux bytearray len (succ cur_pos) buf )
   in
   let len = Bytes.length bytearray in
   let buf_len = 2 * len in
@@ -84,25 +84,18 @@ let decode hexstring =
       match decode_2chars c1 c2 with
       | None -> Error pos
       | Some b ->
-        Bytes.set res res_cur_pos b;
-        aux (succ res_cur_pos) res_len ss res
-    )
-    else
-      Ok res
+          Bytes.set res res_cur_pos b;
+          aux (succ res_cur_pos) res_len ss res )
+    else Ok res
   in
   let len = String.length hexstring in
-  if len mod 2 <> 0 then
-    Error "length must be a multiple of 2"
-  else if len = 0 then
-      Ok Bytes.empty
+  if len mod 2 <> 0 then Error "length must be a multiple of 2"
+  else if len = 0 then Ok Bytes.empty
   else
     let buf_len = len / 2 in
     let buf = Bytes.make buf_len '\x00' in
     aux 0 buf_len hexstring buf
-    |> Result.map_error
-      (fun i ->
-         Printf.sprintf "invalid char at %d" i
-      )
+    |> Result.map_error (fun i -> Printf.sprintf "invalid char at %d" i)
 
 let%test "decoding empty hexstring" =
   let d = decode "" in

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -34,30 +34,30 @@ let%test "encoding" =
 (* helper to decode a byte *)
 
 let decode_1char = function
-  | '0' -> Ok 0
-  | '1' -> Ok 1
-  | '2' -> Ok 2
-  | '3' -> Ok 3
-  | '4' -> Ok 4
-  | '5' -> Ok 5
-  | '6' -> Ok 6
-  | '7' -> Ok 7
-  | '8' -> Ok 8
-  | '9' -> Ok 9
-  | 'a' -> Ok 10
-  | 'b' -> Ok 11
-  | 'c' -> Ok 12
-  | 'd' -> Ok 13
-  | 'e' -> Ok 14
-  | 'f' -> Ok 15
-  | _ -> Error "invalid character"
+  | '0' -> Some 0
+  | '1' -> Some 1
+  | '2' -> Some 2
+  | '3' -> Some 3
+  | '4' -> Some 4
+  | '5' -> Some 5
+  | '6' -> Some 6
+  | '7' -> Some 7
+  | '8' -> Some 8
+  | '9' -> Some 9
+  | 'a' -> Some 10
+  | 'b' -> Some 11
+  | 'c' -> Some 12
+  | 'd' -> Some 13
+  | 'e' -> Some 14
+  | 'f' -> Some 15
+  | _ -> None
 
 let decode_2chars ((c1, c2) : char * char) : (char, string) result =
   let fst = decode_1char c1 in
   let snd = decode_1char c2 in
   match (fst, snd) with
-  | Error _, _ | _, Error _ -> Error "nope"
-  | Ok fst, Ok snd ->
+  | None, _ | _, None -> Error "nope"
+  | Some fst, Some snd ->
       let res = (fst lsl 4) lxor snd in
       Ok (char_of_int res)
 

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -8,8 +8,8 @@ let encode (bytearray : bytes) : string =
     assert (x >= 0);
     assert (x < 16);
     char_of_int
-      ( if x < 10 then x + start_of_digit_0_in_ascii_table
-      else x - 10 + start_of_lower_case_a_in_ascii_table )
+      (if x < 10 then x + start_of_digit_0_in_ascii_table
+      else x - 10 + start_of_lower_case_a_in_ascii_table)
   in
   let rec aux bytearray len cur_pos buf =
     if cur_pos < len then (
@@ -18,7 +18,7 @@ let encode (bytearray : bytes) : string =
       let c2 = hex_digit_of_int (x land 0x0F) in
       Bytes.set buf (cur_pos * 2) c1;
       Bytes.set buf ((cur_pos * 2) + 1) c2;
-      aux bytearray len (succ cur_pos) buf )
+      aux bytearray len (succ cur_pos) buf)
   in
   let len = Bytes.length bytearray in
   let buf_len = 2 * len in
@@ -85,7 +85,7 @@ let decode hexstring =
       | None -> Error pos
       | Some b ->
           Bytes.set res res_cur_pos b;
-          aux (succ res_cur_pos) res_len ss res )
+          aux (succ res_cur_pos) res_len ss res)
     else Ok res
   in
   let len = String.length hexstring in

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -98,7 +98,7 @@ let decode hexstring =
   else
     let buf_len = len / 2 in
     let buf = Bytes.make buf_len '\x00' in
-    (aux 0 buf_len hexstring buf)
+    aux 0 buf_len hexstring buf
     |> Result.map_error
       (fun i ->
          Printf.sprintf "invalid char at %d" i

--- a/lib/hexstring.ml
+++ b/lib/hexstring.ml
@@ -96,10 +96,13 @@ let decode hexstring =
   else if len = 0 then
       Ok Bytes.empty
   else
-    let res = Bytes.make (len / 2) '\x00' in
-    match aux 0 (Bytes.length res) hexstring res with
-    | Error i -> Error (Printf.sprintf "invalid char at %d" i)
-    | Ok bytes -> Ok bytes
+    let buf_len = len / 2 in
+    let buf = Bytes.make buf_len '\x00' in
+    (aux 0 buf_len hexstring buf)
+    |> Result.map_error
+      (fun i ->
+         Printf.sprintf "invalid char at %d" i
+      )
 
 let%test "decoding empty hexstring" =
   let d = decode "" in


### PR DESCRIPTION
- Using `Str.first_chars` and `Str.string_after` to "iterate" (or move the sliding window through) the string induces a lot of allocations
- Passing arguments directly is faster than passing via tuple in general iirc (cause boxed representation etc)